### PR TITLE
03-basics: Fix deprecation warnings and postgres version error

### DIFF
--- a/03-basics/aws-backend/main.tf
+++ b/03-basics/aws-backend/main.tf
@@ -27,15 +27,20 @@ provider "aws" {
 resource "aws_s3_bucket" "terraform_state" {
   bucket        = "devops-directive-tf-state" # REPLACE WITH YOUR BUCKET NAME
   force_destroy = true
-  versioning {
-    enabled = true
-  }
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+resource "aws_s3_bucket_versioning" "terraform_bucket_versioning" {
+  bucket = aws_s3_bucket.terraform_state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state_crypto_conf" {
+  bucket        = aws_s3_bucket.terraform_state.bucket 
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }

--- a/03-basics/web-app/main.tf
+++ b/03-basics/web-app/main.tf
@@ -46,15 +46,20 @@ resource "aws_instance" "instance_2" {
 resource "aws_s3_bucket" "bucket" {
   bucket        = "devops-directive-web-app-data"
   force_destroy = true
-  versioning {
-    enabled = true
-  }
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+resource "aws_s3_bucket_versioning" "bucket_versioning" {
+  bucket = aws_s3_bucket.bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_crypto_conf" {
+  bucket        = aws_s3_bucket.bucket.bucket
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }
@@ -198,13 +203,18 @@ resource "aws_route53_record" "root" {
 }
 
 resource "aws_db_instance" "db_instance" {
-  allocated_storage   = 20
-  storage_type        = "standard"
-  engine              = "postgres"
-  engine_version      = "12.5"
-  instance_class      = "db.t2.micro"
-  name                = "mydb"
-  username            = "foo"
-  password            = "foobarbaz"
-  skip_final_snapshot = true
+  allocated_storage          = 20
+  # This allows any minor version within the major engine_version
+  # defined below, but will also result in allowing AWS to auto
+  # upgrade the minor version of your DB. This may be too risky
+  # in a real production environment.
+  auto_minor_version_upgrade = true
+  storage_type               = "standard"
+  engine                     = "postgres"
+  engine_version             = "12"
+  instance_class             = "db.t2.micro"
+  name                       = "mydb"
+  username                   = "foo"
+  password                   = "foobarbaz"
+  skip_final_snapshot        = true
 }


### PR DESCRIPTION
This change updates the s3 bucket resource syntax to use the newer
resource types for specifying versioning and encryption configs.
We also enable auto_minor_version_upgrade for the RDS instance and
switch to only asking for major version 12.
This will just use the default/latest RDS PostgreSQL v12 minor
version. Upside, the specific engine_version provided here will take
longer before it becomes invalid. Minor downside, we are saying its
OK for this RDS instance to undergo minor version upgrades, which
while fine for a toy example like this, is often not great in prod.