### PR TITLE
Create default VPC and subnet for 02-overview 

### DIFF
--- a/02-overview/main.tf
+++ b/02-overview/main.tf
@@ -2,13 +2,29 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }
 
 provider "aws" {
   region = "us-east-1"
+}
+
+resource "aws_default_vpc" "default" {
+  force_destroy = true
+  tags = {
+    Name = "Default VPC"
+  }
+}
+
+resource "aws_default_subnet" "default_az1" {
+  availability_zone = "us-east-1a"
+  force_destroy     = true
+
+  tags = {
+    Name = "Default subnet for us-east-1a"
+  }
 }
 
 resource "aws_instance" "example" {


### PR DESCRIPTION
## Description
- Create [default VPC](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_vpc) and [subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_subnet) using terraform resources 
- upgraded aws provider to [version 4](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.0.0) to use `force_destroy` on both resources (see known issues from aws provider below)

## Related Issue
Addressed VPCIdNotSpecified error mentioned in https://github.com/sidpalas/devops-directive-terraform-course/issues/7

## How Has This Been Tested?
- Run `terraform init` and verify that `hashicorp/aws v4.x.x` is used.
- Run terraform plan and apply. 
- Verify that resources are created in AWS console.
- Manually detached and delete default internet gateway and delete subnets. Then, run terraform destroy.
- Verify that resources are destroyed in AWS console. `Destroy complete! Resources: 3 destroyed.`

## Screenshots:
![Screenshot 2024-08-23 at 12 15 51 PM](https://github.com/user-attachments/assets/fb7bcb89-b113-4b25-81b4-7623521d6b87)
![Screenshot 2024-08-23 at 12 13 42 PM](https://github.com/user-attachments/assets/25162fda-d69b-4520-9210-4b4ae9d16163)

## Known issues from terraform-provider-aws 
I ran into an issue when destroying the default VPC. The error message is `The vpc 'vpc-xxxxxxxxxxxxxx' has dependencies and cannot be deleted.`  Other resources are implicit created with the `aws_deafult_vpc` resources so based on [AWS's doc](https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html#default-vpc-components), I detached and deleted the default internet gateway and deleted subnet manually in console. Then, run `terraform destroy` to tear down the default VPC. (I had to run it twice cause the terraform-provider-aws_v4.67.0_x5 plugin crashed due to resource change request being cancelled.) This is the workaround that worked for me.  
If you are interested in learning about the root cause, I also found this [draft PR](https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html#default-vpc-components) and looks like they are working on fixing the default VPC bug caused by IGW. Hope this helps!

